### PR TITLE
fix: 用中文输入法的时候，删除字符是不会触发 keydown 事件， 删除空会触发错误

### DIFF
--- a/src/control/input.js
+++ b/src/control/input.js
@@ -302,10 +302,21 @@ define( function ( require, exports, module ) {
         },
 
         processingInput: function () {
+            var inputLatex = this.inputBox.value
+            var isNeedRedraw = null
 
-            this.restruct( this.inputBox.value );
+            if(this.inputBox.value === '') {
+                inputLatex = '\\placeholder'
+                isNeedRedraw = this.kfEditor.requestService( "syntax.delete.group" );
+            }
+
+            this.restruct( inputLatex );
             this.kfEditor.requestService( "ui.update.canvas.view" );
 
+            if ( isNeedRedraw ) {
+                this.updateInput();
+                this.processingInput();
+            }    
         },
 
         // 根据给定的字符串重新进行构造公式


### PR DESCRIPTION
这里有bug演示的过程，在输入法下输入就会触发错误

![kf](https://cloud.githubusercontent.com/assets/4251499/16611894/ae278920-4396-11e6-8d62-a1fb2bf09c14.gif)
